### PR TITLE
Cellio/add proposals

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -124,5 +124,12 @@
         "url_slug": "meta",
         "logo_url": "https://codidact.com/community-assets/meta/logo-large.png",
         "description": "Our meta site for issues regarding community and network governance."
+    },
+    {
+        "name": "Community Proposals",
+        "canonical_url": "https://proposals.codidact.com/",
+        "url_slug": "proposals",
+        "logo_url": "https://codidact.com/community-assets/proposals/logo-large.png",
+        "description": "Our staging ground for new communities.  Ask and answer questions for current proposals or bring new proposals here."
     }
 ]

--- a/communities.json
+++ b/communities.json
@@ -1,5 +1,96 @@
 [
     {
+        "name": "Software Development",
+        "canonical_url": "https://software.codidact.com/",
+        "url_slug": "software",
+        "logo_url": "https://codidact.com/community-assets/software/logo-large.png",
+        "description": "Our community for people involved in software design, programming, testing, architecture, process or tools."
+    },
+    {
+        "name": "Electrical Engineering",
+        "canonical_url": "https://electrical.codidact.com/",
+        "url_slug": "electrical",
+        "logo_url": "https://codidact.com/community-assets/electrical/logo-large.png",
+        "description": "Our community for professionals, hobbyists, and students of electrical and electronic engineering."
+    },
+    {
+        "name": "Mathematics",
+        "canonical_url": "https://math.codidact.com/",
+        "url_slug": "math",
+        "logo_url": "https://codidact.com/community-assets/math/logo-large.png",
+        "description": "Our community for people interested in theoretical and applied mathematics and statistics."
+    },
+    {
+        "name": "Power Users",
+        "canonical_url": "https://powerusers.codidact.com/",
+        "url_slug": "powerusers",
+        "logo_url": "https://codidact.com/community-assets/powerusers/logo-large.png",
+        "description": "Our community for computer enthusiasts (power users) asking and answering questions about software and hardware usage."
+    },
+    {
+        "name": "Linux Systems",
+        "canonical_url": "https://linux.codidact.com/",
+        "url_slug": "linux",
+        "logo_url": "https://codidact.com/community-assets/linux/logo-large.png",
+        "description": "Our community for users of Linux and Unix-like operating systems."
+    },
+    {
+        "name": "Code Golf",
+        "canonical_url": "https://codegolf.codidact.com/",
+        "url_slug": "codegolf",
+        "logo_url": "https://codidact.com/community-assets/codegolf/logo-large.png",
+        "description": "Our community for any and all people interested in recreational coding."
+    },
+    {
+        "name": "Physics",
+        "canonical_url": "https://physics.codidact.com/",
+        "url_slug": "physics",
+        "logo_url": "https://codidact.com/community-assets/physics/logo-large.png",
+        "description": "Our community for anyone interested in physics of any type and at any level."
+    },
+    {
+        "name": "Languages & Linguistics",
+        "canonical_url": "https://languages.codidact.com/",
+        "url_slug": "languages",
+        "logo_url": "https://codidact.com/community-assets/languages/logo-large.png",
+        "description": "Our community for anyone interested in specific (human) languages, language and its constructs more generally, or linguistics."
+    },
+    {
+        "name": "Scientific Speculation",
+        "canonical_url": "https://scientific-speculation.codidact.com/",
+        "url_slug": "scientific-speculation",
+        "logo_url": "https://codidact.com/community-assets/scientific-speculation/logo-large.png",
+        "description": "Our community for anyone interested in worldbuilding or other speculative developments that can be extrapolated from science."
+    },
+    {
+        "name": "Judaism",
+        "canonical_url": "https://judaism.codidact.com/",
+        "url_slug": "judaism",
+        "logo_url": "https://codidact.com/community-assets/judaism/logo-large.png",
+        "description": "Our community for anyone practicing, studying, or interested in Judaism and Jewish life."
+    },
+    {
+        "name": "Christianity",
+        "canonical_url": "https://christianity.codidact.com/",
+        "url_slug": "christianity",
+        "logo_url": "https://codidact.com/community-assets/christianity/logo-large.png",
+        "description": "Our community for anyone practicing, studying, or interested in Christianity and its sacred texts."
+    },
+    {
+        "name": "Cooking",
+        "canonical_url": "https://cooking.codidact.com/",
+        "url_slug": "cooking",
+        "logo_url": "https://codidact.com/community-assets/cooking/logo-large.png",
+        "description": "Our community for people interested in cooking and questions about it - methods, processes, recipes, tips, and recommendations."
+    },
+    {
+        "name": "Tabletop Role-Playing Games",
+        "canonical_url": "https://rpg.codidact.com/",
+        "url_slug": "rpg",
+        "logo_url": "https://codidact.com/community-assets/rpg/logo-large.png",
+        "description": "Our community for people who play, run, develop, or are interested in human-mediated role-playing games of all genres."
+    },
+    {
         "name": "Writing",
         "canonical_url": "https://writing.codidact.com/",
         "url_slug": "writing",
@@ -21,102 +112,11 @@
         "description": "Our community for anyone interested in amateur, hobby, or professional photography, videography, and computer vision."
     },
     {
-        "name": "Scientific Speculation",
-        "canonical_url": "https://scientific-speculation.codidact.com/",
-        "url_slug": "scientific-speculation",
-        "logo_url": "https://codidact.com/community-assets/scientific-speculation/logo-large.png",
-        "description": "Our community for anyone interested in worldbuilding or other speculative developments that can be extrapolated from science."
-    },
-    {
-        "name": "Cooking",
-        "canonical_url": "https://cooking.codidact.com/",
-        "url_slug": "cooking",
-        "logo_url": "https://codidact.com/community-assets/cooking/logo-large.png",
-        "description": "Our community for people interested in cooking and questions about it - methods, processes, recipes, tips, and recommendations."
-    },
-    {
-        "name": "Electrical Engineering",
-        "canonical_url": "https://electrical.codidact.com/",
-        "url_slug": "electrical",
-        "logo_url": "https://codidact.com/community-assets/electrical/logo-large.png",
-        "description": "Our community for professionals, hobbyists, and students of electrical and electronic engineering."
-    },
-    {
-        "name": "Judaism",
-        "canonical_url": "https://judaism.codidact.com/",
-        "url_slug": "judaism",
-        "logo_url": "https://codidact.com/community-assets/judaism/logo-large.png",
-        "description": "Our community for anyone practicing, studying, or interested in Judaism and Jewish life."
-    },
-    {
-        "name": "Languages & Linguistics",
-        "canonical_url": "https://languages.codidact.com/",
-        "url_slug": "languages",
-        "logo_url": "https://codidact.com/community-assets/languages/logo-large.png",
-        "description": "Our community for anyone interested in specific (human) languages, language and its constructs more generally, or linguistics."
-    },
-    {
-        "name": "Software Development",
-        "canonical_url": "https://software.codidact.com/",
-        "url_slug": "software",
-        "logo_url": "https://codidact.com/community-assets/software/logo-large.png",
-        "description": "Our community for people involved in software design, programming, testing, architecture, process or tools."
-    },
-    {
-        "name": "Mathematics",
-        "canonical_url": "https://math.codidact.com/",
-        "url_slug": "math",
-        "logo_url": "https://codidact.com/community-assets/math/logo-large.png",
-        "description": "Our community for people interested in theoretical and applied mathematics and statistics."
-    },
-    {
-        "name": "Code Golf",
-        "canonical_url": "https://codegolf.codidact.com/",
-        "url_slug": "codegolf",
-        "logo_url": "https://codidact.com/community-assets/codegolf/logo-large.png",
-        "description": "Our community for any and all people interested in recreational coding."
-    },
-    {
-        "name": "Christianity",
-        "canonical_url": "https://christianity.codidact.com/",
-        "url_slug": "christianity",
-        "logo_url": "https://codidact.com/community-assets/christianity/logo-large.png",
-        "description": "Our community for anyone practicing, studying, or interested in Christianity and its sacred texts."
-    },
-    {
         "name": "Music",
         "canonical_url": "https://music.codidact.com/",
         "url_slug": "music",
         "logo_url": "https://codidact.com/community-assets/music/logo-large.png",
         "description": "Our community for music artists, composers, and fans."
-    },
-    {
-        "name": "Physics",
-        "canonical_url": "https://physics.codidact.com/",
-        "url_slug": "physics",
-        "logo_url": "https://codidact.com/community-assets/physics/logo-large.png",
-        "description": "Our community for anyone interested in physics of any type and at any level."
-    },
-    {
-        "name": "Linux Systems",
-        "canonical_url": "https://linux.codidact.com/",
-        "url_slug": "linux",
-        "logo_url": "https://codidact.com/community-assets/linux/logo-large.png",
-        "description": "Our community for users of Linux and Unix-like operating systems."
-    },
-    {
-        "name": "Power Users",
-        "canonical_url": "https://powerusers.codidact.com/",
-        "url_slug": "powerusers",
-        "logo_url": "https://codidact.com/community-assets/powerusers/logo-large.png",
-        "description": "Our community for computer enthusiasts (power users) asking and answering questions about software and hardware usage."
-    },
-    {
-        "name": "Tabletop Role-Playing Games",
-        "canonical_url": "https://rpg.codidact.com/",
-        "url_slug": "rpg",
-        "logo_url": "https://codidact.com/community-assets/rpg/logo-large.png",
-        "description": "Our community for people who play, run, develop, or are interested in human-mediated role-playing games of all genres."
     },
     {
         "name": "Codidact Meta",

--- a/index.html
+++ b/index.html
@@ -374,6 +374,25 @@
                     </div>
                 </div>
 
+                <div class="grid--cell is-4 is-6-md is-12-sm">
+                    <div class="widget" data-name="proposals">
+                        <div class="widget--header is-complex">
+                            <div class="has-text-align-center has-font-weight-bold has-font-size-display">
+                                <a href="https://proposals.codidact.com"
+                                    style="display: flex; align-items: center; justify-content: center;">
+                                        <img src="./community-assets/proposals/logo-large.png" alt="Proposals" style="height: 1.5em">
+                                </a>
+                            </div>
+                        </div>
+                        <div class="widget--body">
+			  <p>Our staging ground for new communities.  Ask and answer questions for current proposals or bring new proposals here.</p>
+                        </div>
+                        <div class="widget--footer">
+                            <a href="https://proposals.codidact.com" class="button is-filled">Visit the community</a>
+                        </div>
+                    </div>
+                </div>
+
             </div>
 
             <h1>The community I want isn't here!</h1>


### PR DESCRIPTION
Added proposals site to list, reordered JSON to match index file.  The latter means that the order in the page footer will match codidact.com but probably disagree with the site switcher, which seems to get its list elsewhere.  (I infer that from the position of Meta in the site switcher.)  I think this is an acceptable tradeoff; the page footer, like .com, is there to promote communities, so we want to put the more active ones first.  The switcher, on the other hand, serves people who are already active on the listed communities.

Also resolves https://github.com/codidact/community-list/issues/14 (though not in the way requested there).