### PR TITLE
Add GitHub/OSS info to contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -46,12 +46,15 @@
                     <a href="mailto:support@codidact.org">support@codidact.org</a>, mentioning SECURITY in the subject
                     line.
                 </p>
-        
+
+		<h2>GitHub</h2>
+		<p>Codidact is an open-source project.  If you find a bug or are requesting a change, you're welcome to report an issue in <a href="https://github.com/codidact/qpixel">our primary repository</a>.  You can also use Meta (next option).  Don't worry about choosing between GitHub and Meta; we'll make sure issues and discussions end up in the right places.
+		</p>
                 <h2>Meta</h2>
                 <p>
                     If you're asking about how our sites or the organisation operates, or if you've got a feature request or a
                     bug report, <a href="https://meta.codidact.com/">Meta</a> is the place to do that. Post there with the
-                    details, and either the community will be able to answer or our staff can get back to you.
+                    details, and either the community will be able to answer or our staff can get back to you.  (It's ok to use GitHub if you prefer.  If something comes up on GitHub that the community should discuss, we'll bring it to Meta.)
                 </p>
         
                 <h2>Support</h2>


### PR DESCRIPTION
Added GitHub issues to list of ways to reach us (and link to the primary repo as part of that).

Fixes https://github.com/codidact/community-list/issues/19 -- better late than never?