### PR TITLE
Add Discord, Collab and, reorder

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -59,7 +59,7 @@
 		</p>
 
 		<h2>Chat</h2>
-		<p>We also have two chat servers! You are welcome to join our <a href="https://discord.gg/bv2aaGa">community chat server</a>, and alternatively, our <a href="https://discord.gg/7jf8UzS">development server</a> if you're interested in the development of Codidact.</p>
+		<p>We also have two chat servers! You are welcome to join our <a href="https://discord.gg/bv2aaGa">community chat server, where our regulars hang out for chats and discussions</a>, and alternatively, our <a href="https://discord.gg/7jf8UzS">development server</a> if you're interested in the development of Codidact.</p>
         
                 <h2>Support</h2>
                 <p>

--- a/contact.html
+++ b/contact.html
@@ -46,22 +46,27 @@
                     <a href="mailto:support@codidact.org">support@codidact.org</a>, mentioning SECURITY in the subject
                     line.
                 </p>
-
-		<h2>GitHub</h2>
-		<p>Codidact is an open-source project.  If you find a bug or are requesting a change, you're welcome to report an issue in <a href="https://github.com/codidact/qpixel">our primary repository</a>.  You can also use Meta (next option).  Don't worry about choosing between GitHub and Meta; we'll make sure issues and discussions end up in the right places.
-		</p>
+		    
                 <h2>Meta</h2>
                 <p>
                     If you're asking about how our sites or the organisation operates, or if you've got a feature request or a
                     bug report, <a href="https://meta.codidact.com/">Meta</a> is the place to do that. Post there with the
-                    details, and either the community will be able to answer or our staff can get back to you.  (It's ok to use GitHub if you prefer.  If something comes up on GitHub that the community should discuss, we'll bring it to Meta.)
+                    details, and either the community will be able to answer or our staff can get back to you.
                 </p>
+
+		<h2>GitHub</h2>
+		<p>Codidact is an open-source project. As an alternative to Meta, if you find a bug or are requesting a change, you're welcome to open an issue in <a href="https://github.com/codidact/qpixel">our primary repository</a>.  You can also use Meta.  Don't worry about choosing between GitHub and Meta; we'll make sure issues and discussions end up in the right places.
+		</p>
+
+		<h2>Chat</h2>
+		<p>We also have two chat servers! You are welcome to join our <a href="https://discord.gg/bv2aaGa">community chat server</a>, and alternatively, our <a href="https://discord.gg/7jf8UzS">development server</a> if you're interested in the development of Codidact.</p>
         
                 <h2>Support</h2>
                 <p>
                     If you need to get in touch for support with your Codidact account or something else, use our
                     <a href="https://codidact.atlassian.net/servicedesk/customer/portal/1">support portal</a>, or email
                     us at <a href="mailto:support@codidact.org">support@codidact.org</a>.
+                    We also host the <a href="https://collab.codidact.org/">Codidact Collab community</a> for questions and answers about QPixel, if you are contributing to the code base, or trying to set up our software to run for yourself.
                 </p>
 
                 <h2>Enquiries</h2>


### PR DESCRIPTION
Added the Discord chat servers, reordered the Meta section above Github, and added a mention of Collab to the Support section. Also removed a redundant sentence from the Meta section (it's repeated in the Github section).

I don't have a test environment set up, so I haven't tested the changes, but they're fairly simple and small; should be unnecessary.