### PR TITLE
address feedback that .org and our goals were too hard to find

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
     <main class="container has-padding-4">
             <h1>Communities</h1>
             <p class="is-lead">Welcome to Codidact, the community-run, open-source Q&amp;A platform. We're working together to build communities around high-quality, peer-reviewed questions, answers, articles, and other content. Codidact puts people first; we're here to help you share knowledge and get curated answers in a friendly environment.</p>
+	    <p>Codidact serves communities, not shareholders. You can learn more about <a href="https://codidact.org">our non-profit project</a> and <a href="https://meta.codidact.com/posts/276296">the Codidact vision</a>.</p>
             <p>We currently host the following communities:</p>
             <div class="grid community-list">
 


### PR DESCRIPTION
I've heard a couple times that it's not obvious to outsiders what distinguishes us.  This PR adds links to `.org` and our vision blog post to `.com` near the top.  (`.org` is linked in the FAQ at the bottom, I know.)